### PR TITLE
Make Blink compatible with object files built with `/bigobj`

### DIFF
--- a/blink.vcxproj
+++ b/blink.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{188B7270-046B-476D-A32D-34390DA1A885}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/source/blink_linker.cpp
+++ b/source/blink_linker.cpp
@@ -546,20 +546,16 @@ bool blink::application::link(const std::filesystem::path &path)
 	// Read symbol table from input file
 	SetFilePointer(file, ptr_to_symbol_table, nullptr, FILE_BEGIN);
 
-	//std::vector<IMAGE_SYMBOL> symbols(nb_symbols);
+	// Create templated symbol list
 	std::unique_ptr<generic_symbol_list> symbols_ptr;
-
 	if(!need_extended_symbol)
-	{
 		symbols_ptr = std::make_unique<symbol_list<IMAGE_SYMBOL>>(nb_symbols);
-	}
 	else
-	{
 		symbols_ptr = std::make_unique<symbol_list<IMAGE_SYMBOL_EX>>(nb_symbols);
-	}
 
-
+	// Perform link with the right kind of symbol records
 	if(need_extended_symbol)
 		return perform_link_with_symbol_type<IMAGE_SYMBOL_EX>(_image_base, _symbols, file, nb_symbols, symbols_ptr.get(), ptr_to_symbol_table, sections, read);
-	return perform_link_with_symbol_type<IMAGE_SYMBOL>(_image_base, _symbols, file, nb_symbols, symbols_ptr.get(), ptr_to_symbol_table, sections, read);
+	else
+		return perform_link_with_symbol_type<IMAGE_SYMBOL>(_image_base, _symbols, file, nb_symbols, symbols_ptr.get(), ptr_to_symbol_table, sections, read);
 }


### PR DESCRIPTION
See discussion in issue #23 

Do not merge yet : 

If things are going to get built with /bigobj too. The code that does the "linking and patching" needs a similar modification.

Probably around here : https://github.com/crosire/blink/blob/master/source/blink_linker.cpp#L136