### PR TITLE
Actually check the ClassID inside the COFF header

### DIFF
--- a/source/coff_reader.hpp
+++ b/source/coff_reader.hpp
@@ -10,8 +10,16 @@
 
 union COFF_HEADER
 {
+	constexpr static const uint8_t bigobj_classid[16] = {
+		0xc7, 0xa1, 0xba, 0xd1, 0xee, 0xba, 0xa9, 0x4b,
+		0xaf, 0x20, 0xfa, 0xf6, 0x6a, 0xa4, 0xdc, 0xb8,
+	};
+
+	//This is actually a 16byte UUID
+	static_assert(sizeof(bigobj_classid) == sizeof(CLSID));
+
 	bool is_extended() const {
-		return bigobj.Sig1 == 0x0000 && bigobj.Sig2 == 0xFFFF;
+		return bigobj.Sig1 == 0x0000 && bigobj.Sig2 == 0xFFFF && memcmp(&bigobj.ClassID, bigobj_classid, sizeof(CLSID)) == 0 ;
 	}
 
 	IMAGE_FILE_HEADER obj;


### PR DESCRIPTION
The actual signature of an extended COFF is on 3 fields :

Machine type 		-> IMAGE_FILE_MACHINE_UNKNOWN (0)
Number of Sections 	-> FFFF
Class ID		-> {D1BAA1C7-BAEE-4ba9-AF20-FAF66AA4DCB8}

This patch adds the missing check of the Class ID inside the "is_extended" function.

For matter of simplicity, I've filed in the 16 byte array as a static
constant inside the header. The actual value of the classid is only
documented in comments, but there's no pre-filled structure containing it.

Now we can be assured to have a robust way of checking for an extended COFF file.