### PR TITLE
Allow watching multiple drives

### DIFF
--- a/source/blink.cpp
+++ b/source/blink.cpp
@@ -160,10 +160,9 @@ void blink::application::run()
 		auto source_dir = *it;
 		print("Starting file system watcher for '" + source_dir.string() + "' ...");
 
-		dir_handles.emplace_back(INVALID_HANDLE_VALUE);
-		event_handles.emplace_back(INVALID_HANDLE_VALUE);
-		notification_info info;
-		notification_infos.emplace_back(info);
+		dir_handles.emplace_back();
+		event_handles.emplace_back();
+		notification_infos.emplace_back();
 
 		if (!set_watch(dir_index, dir_handles, event_handles, notification_infos))
 			return;

--- a/source/blink.cpp
+++ b/source/blink.cpp
@@ -30,7 +30,7 @@ static void common_paths(const std::vector<std::filesystem::path> &paths, std::v
 	add_unique_path(source_dirs, paths[0].parent_path());
 
 	for (auto path_it = paths.begin() + 1; path_it != paths.end(); ++path_it) {
-		// only consider paths that exist, ie: can be watched
+		// only consider files that exist, ie: can be watched
 		if (!std::filesystem::exists(*path_it)) {
 			continue;
 		}
@@ -42,20 +42,13 @@ static void common_paths(const std::vector<std::filesystem::path> &paths, std::v
 			for (auto it2 = file_directory.begin(), it3 = source_dir.begin(); it2 != file_directory.end() && it3 != source_dir.end() && *it2 == *it3; ++it2, ++it3) {
 				common_path /= *it2;
 			}
-			if (common_path.u8string().length() < 8) {
-				bool test = true;
-			}
-
 			if (!common_path.empty()) {
 				found_path = true;
 				*dir_it = common_path;
 			}
 		}
-		if (!found_path) {
-			// add the drive letter
-			if (file_directory.begin() != file_directory.end()) {
-				add_unique_path(source_dirs, file_directory);
-			}
+		if (!found_path && !file_directory.empty()) {
+			add_unique_path(source_dirs, file_directory);
 		}
 	}
 }

--- a/source/blink.cpp
+++ b/source/blink.cpp
@@ -10,7 +10,7 @@
 #include <algorithm>
 #include <unordered_map>
 
-static void add_unique_path(std::vector<std::filesystem::path>& paths, const std::filesystem::path &path)
+static void add_unique_path(std::vector<std::filesystem::path> &paths, const std::filesystem::path &path)
 {
 	if (path.empty())
 		return;
@@ -362,7 +362,7 @@ void blink::application::read_import_address_table(const BYTE *image_base)
 void blink::application::set_watch(
 	const size_t dir_index,
 	std::vector<scoped_handle> &dir_handles,
-	std::vector<scoped_handle>& event_handles,
+	std::vector<scoped_handle> &event_handles,
 	std::vector<notification_info> &notification_infos)
 {
 	dir_handles[dir_index].reset(CreateFileW(_source_dirs[dir_index].native().c_str(),

--- a/source/blink.hpp
+++ b/source/blink.hpp
@@ -61,7 +61,7 @@ namespace blink
 		bool read_debug_info(const uint8_t *image_base);
 		void read_import_address_table(const uint8_t *image_base);
 
-		void set_watch(
+		bool set_watch(
 			const size_t dir_index,
 			std::vector<scoped_handle> &dir_handles,
 			std::vector<scoped_handle> &event_handles,

--- a/source/blink.hpp
+++ b/source/blink.hpp
@@ -53,7 +53,7 @@ namespace blink
 		std::string build_compile_command_line(const std::filesystem::path &source_file, std::filesystem::path &object_file) const;
 
 		uint8_t *_image_base = nullptr;
-		std::filesystem::path _source_dir;
+		std::vector<std::filesystem::path> _source_dirs;
 		std::vector<std::filesystem::path> _object_files;
 		std::vector<std::vector<std::filesystem::path>> _source_files;
 		std::unordered_map<std::string, void *> _symbols;

--- a/source/blink.hpp
+++ b/source/blink.hpp
@@ -5,11 +5,13 @@
 
 #pragma once
 
+#include "scoped_handle.hpp"
 #include <vector>
 #include <string>
 #include <filesystem>
 #include <unordered_set>
 #include <unordered_map>
+#include <Windows.h>
 
 void print(const char *message, size_t length);
 inline void print(std::string message)
@@ -44,12 +46,26 @@ namespace blink
 		}
 
 	private:
+		struct free_delete
+		{
+			void operator()(void* x) { free(x); }
+		};
+		struct notification_info {
+			std::shared_ptr<FILE_NOTIFY_INFORMATION> p_info;
+			OVERLAPPED overlapped;
+		};
+
 		template <typename SYMBOL_TYPE, typename HEADER_TYPE>
 		bool link(void *const object_file, const HEADER_TYPE &header);
 
 		bool read_debug_info(const uint8_t *image_base);
 		void read_import_address_table(const uint8_t *image_base);
 
+		void set_watch(
+			const size_t dir_index,
+			std::vector<scoped_handle>& dir_handles,
+			std::vector<scoped_handle>& event_handles,
+			std::vector<notification_info>& notification_infos);
 		std::string build_compile_command_line(const std::filesystem::path &source_file, std::filesystem::path &object_file) const;
 
 		uint8_t *_image_base = nullptr;

--- a/source/blink.hpp
+++ b/source/blink.hpp
@@ -47,12 +47,13 @@ namespace blink
 		}
 
 	private:
-		struct free_delete
+		class notification_info
 		{
-			void operator()(void *x) { free(x); }
-		};
-		struct notification_info {
-			std::shared_ptr<FILE_NOTIFY_INFORMATION> p_info;
+			public:
+				notification_info() : p_info(buffer_size), overlapped({ 0 }) {}
+
+			const size_t buffer_size = 4096;
+			std::vector<BYTE> p_info;
 			OVERLAPPED overlapped;
 		};
 

--- a/source/blink.hpp
+++ b/source/blink.hpp
@@ -48,7 +48,7 @@ namespace blink
 	private:
 		struct free_delete
 		{
-			void operator()(void* x) { free(x); }
+			void operator()(void *x) { free(x); }
 		};
 		struct notification_info {
 			std::shared_ptr<FILE_NOTIFY_INFORMATION> p_info;
@@ -63,9 +63,9 @@ namespace blink
 
 		void set_watch(
 			const size_t dir_index,
-			std::vector<scoped_handle>& dir_handles,
-			std::vector<scoped_handle>& event_handles,
-			std::vector<notification_info>& notification_infos);
+			std::vector<scoped_handle> &dir_handles,
+			std::vector<scoped_handle> &event_handles,
+			std::vector<notification_info> &notification_infos);
 		std::string build_compile_command_line(const std::filesystem::path &source_file, std::filesystem::path &object_file) const;
 
 		uint8_t *_image_base = nullptr;

--- a/source/scoped_handle.hpp
+++ b/source/scoped_handle.hpp
@@ -21,6 +21,13 @@ struct scoped_handle
 
 	operator HANDLE() const { return handle; }
 
+	void reset(const HANDLE p) {
+		if (handle != p) {
+			if (handle != NULL && handle != INVALID_HANDLE_VALUE) CloseHandle(handle);
+			handle = p;
+		}
+	}
+
 	HANDLE *operator&() { return &handle; }
 	const HANDLE *operator&() const { return &handle; }
 };


### PR DESCRIPTION
Allow watching source files on multiple drives. For example, watch folders c:\somepath1 and d:\somepath2