### PR TITLE
Use duplex named pipe, so remote thread can quit

### DIFF
--- a/source/blink.hpp
+++ b/source/blink.hpp
@@ -28,7 +28,7 @@ namespace blink
 	public:
 		application();
 
-		void run();
+		void run(HANDLE blink_handle);
 		bool link(const std::filesystem::path &object_file);
 
 		template <typename T>


### PR DESCRIPTION
I want to Ctrl+C the blink.exe console and have that operation cause the remote thread to quit and free up memory.
This way, my app's memory leak checks don't report the remote thread allocs.

