### PR TITLE
Use blink.exe's environment and working directory for compiles

### DIFF
--- a/source/blink.cpp
+++ b/source/blink.cpp
@@ -57,7 +57,7 @@ blink::application::application()
 	_symbols.insert({ "__ImageBase", _image_base });
 }
 
-void blink::application::run(HANDLE blink_handle, TCHAR* blink_environment, TCHAR* blink_working_directory)
+void blink::application::run(HANDLE blink_handle, wchar_t* blink_environment, wchar_t* blink_working_directory)
 {
 	std::vector<const BYTE *> dlls;
 

--- a/source/blink.cpp
+++ b/source/blink.cpp
@@ -57,7 +57,7 @@ blink::application::application()
 	_symbols.insert({ "__ImageBase", _image_base });
 }
 
-void blink::application::run(HANDLE blink_handle)
+void blink::application::run(HANDLE blink_handle, TCHAR* blink_environment, TCHAR* blink_working_directory)
 {
 	std::vector<const BYTE *> dlls;
 
@@ -135,7 +135,12 @@ void blink::application::run(HANDLE blink_handle)
 		TCHAR cmdline[] = TEXT("cmd.exe /q /d /k @echo off");
 		PROCESS_INFORMATION pi;
 
-		if (!CreateProcess(nullptr, cmdline, nullptr, nullptr, TRUE, CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi))
+		// Use blink.exe's environment and working directory for our compiler process.
+		// This way, the user can run blink.exe from their build prompt and our compiler
+		// process will run compiles similar to how they run from the user's prompt.
+		if (!CreateProcess(nullptr, cmdline, nullptr, nullptr, TRUE,
+			CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW, reinterpret_cast<LPVOID>(blink_environment),
+			blink_working_directory, &si, &pi))
 		{
 			print("  Error: Could not create process.");
 

--- a/source/blink.hpp
+++ b/source/blink.hpp
@@ -28,7 +28,7 @@ namespace blink
 	public:
 		application();
 
-		void run(HANDLE blink_handle);
+		void run(HANDLE blink_handle, TCHAR* blink_environment, TCHAR* blink_working_directory);
 		bool link(const std::filesystem::path &object_file);
 
 		template <typename T>

--- a/source/blink.hpp
+++ b/source/blink.hpp
@@ -28,7 +28,7 @@ namespace blink
 	public:
 		application();
 
-		void run(HANDLE blink_handle, TCHAR* blink_environment, TCHAR* blink_working_directory);
+		void run(HANDLE blink_handle, wchar_t* blink_environment, wchar_t* blink_working_directory);
 		bool link(const std::filesystem::path &object_file);
 
 		template <typename T>

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -28,8 +28,8 @@ extern "C" void _initterm(_PVFV *beg, _PVFV *end);
 HANDLE console = INVALID_HANDLE_VALUE;
 char blink_pipe_name[MAX_PATH];
 #define MAX_ENVIRONMENT_LENGTH 32767 // max for Windows
-TCHAR blink_environment[MAX_ENVIRONMENT_LENGTH];
-TCHAR blink_working_directory[MAX_PATH];
+wchar_t blink_environment[MAX_ENVIRONMENT_LENGTH];
+wchar_t blink_working_directory[MAX_PATH];
 
 void print(const char *message, size_t length)
 {


### PR DESCRIPTION
Use blink.exe's environment and working directory for the compiler process. This way, the user can run blink.exe from their build prompt and our compiler process will run compiles similar to how they run from the user's prompt.